### PR TITLE
add extra OnScrollListener(s) in QuickReturn list.

### DIFF
--- a/app/src/main/java/com/etiennelawlor/quickreturn/activities/QuickReturnListViewActivity.java
+++ b/app/src/main/java/com/etiennelawlor/quickreturn/activities/QuickReturnListViewActivity.java
@@ -19,6 +19,7 @@ import com.etiennelawlor.quickreturn.fragments.QuickReturnFooterListFragment3;
 import com.etiennelawlor.quickreturn.fragments.QuickReturnHeaderListFragment;
 import com.etiennelawlor.quickreturn.fragments.QuickReturnHeaderListFragment2;
 import com.etiennelawlor.quickreturn.fragments.QuickReturnHeaderListFragment3;
+import com.etiennelawlor.quickreturn.fragments.QuickReturnWithExtraOnScrollListenerFragment;
 import com.etiennelawlor.quickreturn.interfaces.QuickReturnInterface;
 import com.etiennelawlor.quickreturn.library.utils.QuickReturnUtils;
 
@@ -157,6 +158,8 @@ public class QuickReturnListViewActivity extends QuickReturnBaseActivity impleme
                     return QuickReturnFooterListFragment3.newInstance();
                 case 5:
                     return QuickReturnFooterListFragment2.newInstance();
+                case 6:
+                    return QuickReturnWithExtraOnScrollListenerFragment.newInstance();
                 default:
                     return QuickReturnHeaderListFragment.newInstance();
             }
@@ -164,7 +167,7 @@ public class QuickReturnListViewActivity extends QuickReturnBaseActivity impleme
 
         @Override
         public int getCount() {
-            return 6;
+            return 7;
         }
 
         @Override
@@ -182,6 +185,8 @@ public class QuickReturnListViewActivity extends QuickReturnBaseActivity impleme
                     return "QRFooter2";
                 case 5:
                     return "SpeedyQRFooter";
+                case 6:
+                    return "WithExtraOnScrollListener";
             }
             return null;
         }

--- a/app/src/main/java/com/etiennelawlor/quickreturn/fragments/QuickReturnHeaderListFragment3.java
+++ b/app/src/main/java/com/etiennelawlor/quickreturn/fragments/QuickReturnHeaderListFragment3.java
@@ -24,6 +24,8 @@ public class QuickReturnHeaderListFragment3 extends ListFragment {
     // region Member Variables
     private String[] mValues;
 
+    protected QuickReturnListViewOnScrollListener mQuickReturnListViewOnScrollListener; // for demo usage
+
     @InjectView(android.R.id.list) ListView mListView;
     @InjectView(R.id.quick_return_tv) TextView mQuickReturnTextView;
     // endregion
@@ -67,12 +69,12 @@ public class QuickReturnHeaderListFragment3 extends ListFragment {
 
         // Set up the QuickReturn scroll listener
         int headerHeight = getActivity().getResources().getDimensionPixelSize(R.dimen.header_height2);
-        QuickReturnListViewOnScrollListener scrollListener = new QuickReturnListViewOnScrollListener(QuickReturnType.HEADER,
+        mQuickReturnListViewOnScrollListener = new QuickReturnListViewOnScrollListener(QuickReturnType.HEADER,
                 mQuickReturnTextView, -headerHeight, null, 0);
         // Setting to true will slide the header and/or footer into view or slide out of view based
         // on what is visible in the idle scroll state
-        scrollListener.setCanSlideInIdleScrollState(true);
-        mListView.setOnScrollListener(scrollListener);
+        mQuickReturnListViewOnScrollListener.setCanSlideInIdleScrollState(true);
+        mListView.setOnScrollListener(mQuickReturnListViewOnScrollListener);
     }
 
     @Override

--- a/app/src/main/java/com/etiennelawlor/quickreturn/fragments/QuickReturnWithExtraOnScrollListenerFragment.java
+++ b/app/src/main/java/com/etiennelawlor/quickreturn/fragments/QuickReturnWithExtraOnScrollListenerFragment.java
@@ -1,0 +1,43 @@
+package com.etiennelawlor.quickreturn.fragments;
+
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.AbsListView;
+import android.widget.ProgressBar;
+
+/**
+ * Quick return effect with extra scroll-to-bottom {@link android.widget.AbsListView.OnScrollListener}
+ *
+ * @author longkai
+ */
+public class QuickReturnWithExtraOnScrollListenerFragment extends QuickReturnHeaderListFragment3 implements AbsListView.OnScrollListener {
+    public static final String TAG = QuickReturnWithExtraOnScrollListenerFragment.class.getSimpleName();
+
+    public static QuickReturnWithExtraOnScrollListenerFragment newInstance() {
+        QuickReturnWithExtraOnScrollListenerFragment fragment = new QuickReturnWithExtraOnScrollListenerFragment();
+        fragment.setArguments(new Bundle());
+        return fragment;
+    }
+
+    @Override public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // now append our scroll to bottom load-more listener with the quick return effect
+        mQuickReturnListViewOnScrollListener.registerExtraOnScrollListener(this);
+    }
+
+    @Override public void onScrollStateChanged(AbsListView view, int scrollState) {
+        // no-op
+    }
+
+    @Override public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+        if (firstVisibleItem + visibleItemCount == totalItemCount && getListView().getFooterViewsCount() == 0) {
+            ProgressBar progressBar = new ProgressBar(getActivity());
+            progressBar.setLayoutParams(new AbsListView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+            progressBar.setPadding(8, 8, 8, 8);
+            getListView().addFooterView(progressBar);
+        }
+    }
+}

--- a/library/src/main/java/com/etiennelawlor/quickreturn/library/listeners/QuickReturnListViewOnScrollListener.java
+++ b/library/src/main/java/com/etiennelawlor/quickreturn/library/listeners/QuickReturnListViewOnScrollListener.java
@@ -7,6 +7,9 @@ import android.widget.AbsListView;
 import com.etiennelawlor.quickreturn.library.enums.QuickReturnType;
 import com.etiennelawlor.quickreturn.library.utils.QuickReturnUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by etiennelawlor on 7/10/14.
  */
@@ -22,6 +25,8 @@ public class QuickReturnListViewOnScrollListener implements AbsListView.OnScroll
     private View mFooter;
     private QuickReturnType mQuickReturnType;
     private boolean mCanSlideInIdleScrollState = false;
+
+    private List<AbsListView.OnScrollListener> mExtraOnScrollListenerList = new ArrayList<AbsListView.OnScrollListener>();
     // endregion
 
     // region Constructors
@@ -37,7 +42,10 @@ public class QuickReturnListViewOnScrollListener implements AbsListView.OnScroll
     @Override
     public void onScrollStateChanged(AbsListView view, int scrollState) {
 //        Log.d(getClass().getSimpleName(), "onScrollStateChanged() : scrollState - "+scrollState);
-
+        // apply another list' s on scroll listener
+        for (AbsListView.OnScrollListener listener : mExtraOnScrollListenerList) {
+          listener.onScrollStateChanged(view, scrollState);
+        }
         if(scrollState == SCROLL_STATE_IDLE && mCanSlideInIdleScrollState){
 
             int midHeader = -mMinHeaderTranslation/2;
@@ -127,6 +135,10 @@ public class QuickReturnListViewOnScrollListener implements AbsListView.OnScroll
 
     @Override
     public void onScroll(AbsListView listview, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+        // apply extra on scroll listener
+        for (AbsListView.OnScrollListener listener : mExtraOnScrollListenerList) {
+          listener.onScroll(listview, firstVisibleItem, visibleItemCount, totalItemCount);
+        }
         int scrollY = QuickReturnUtils.getScrollY(listview);
         int diff = mPrevScrollY - scrollY;
 
@@ -191,5 +203,9 @@ public class QuickReturnListViewOnScrollListener implements AbsListView.OnScroll
 
     public void setCanSlideInIdleScrollState(boolean canSlideInIdleScrollState){
         mCanSlideInIdleScrollState = canSlideInIdleScrollState;
+    }
+
+    public void registerExtraOnScrollListener(AbsListView.OnScrollListener listener) {
+        mExtraOnScrollListenerList.add(listener);
     }
 }

--- a/library/src/main/java/com/etiennelawlor/quickreturn/library/listeners/SpeedyQuickReturnListViewOnScrollListener.java
+++ b/library/src/main/java/com/etiennelawlor/quickreturn/library/listeners/SpeedyQuickReturnListViewOnScrollListener.java
@@ -12,6 +12,7 @@ import com.etiennelawlor.quickreturn.library.enums.QuickReturnType;
 import com.etiennelawlor.quickreturn.library.utils.QuickReturnUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by etiennelawlor on 7/14/14.
@@ -30,6 +31,7 @@ public class SpeedyQuickReturnListViewOnScrollListener implements AbsListView.On
     private Animation mSlideHeaderDownAnimation;
     private Animation mSlideFooterUpAnimation;
     private Animation mSlideFooterDownAnimation;
+    private List<AbsListView.OnScrollListener> mExtraOnScrollListeners = new ArrayList<AbsListView.OnScrollListener>();
     // endregion
 
     // region Constructors
@@ -63,11 +65,18 @@ public class SpeedyQuickReturnListViewOnScrollListener implements AbsListView.On
 
     @Override
     public void onScrollStateChanged(AbsListView view, int scrollState) {
-
+      // apply extra listener first
+      for (AbsListView.OnScrollListener listener : mExtraOnScrollListeners) {
+          listener.onScrollStateChanged(view, scrollState);
+      }
     }
 
     @Override
     public void onScroll(AbsListView listview, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+        // apply extra listener first
+        for (AbsListView.OnScrollListener listener : mExtraOnScrollListeners) {
+            listener.onScroll(listview, firstVisibleItem, visibleItemCount, totalItemCount);
+        }
         int scrollY = QuickReturnUtils.getScrollY(listview);
         int diff = mPrevScrollY - scrollY;
 
@@ -176,6 +185,9 @@ public class SpeedyQuickReturnListViewOnScrollListener implements AbsListView.On
         mPrevScrollY = scrollY;
     }
 
+    public void registerExtraOnScrollListener(AbsListView.OnScrollListener listener) {
+        mExtraOnScrollListeners.add(listener);
+    }
 
     public void setSlideHeaderUpAnimation(Animation animation){
         mSlideHeaderUpAnimation = animation;


### PR DESCRIPTION
both `QuickReturnListViewOnScrollListener` and `SpeedyQuickReturnScrollViewOnScrollChangedListener` has the ability to add extra `android.widget.AbsListView.OnScrollListener`, for example, we can add extra scroll-to-bottom to load more item in the quick-return listview.

add a demo at the last page in the app' s listview demo pager.
